### PR TITLE
Rendering of media only blocks fails

### DIFF
--- a/src/Providers/BlockTemplatesServiceProvider.php
+++ b/src/Providers/BlockTemplatesServiceProvider.php
@@ -99,7 +99,7 @@ class BlockTemplatesServiceProvider extends ServiceProvider
      */
     protected function hasContent($content): bool
     {
-        return !empty(wp_strip_all_tags($content, true));
+        return !empty(wp_strip_all_tags($content, true)) || preg_match('/<(img|video|figure)/i', $content);
     }
 
     /**


### PR DESCRIPTION
Currently the [hasContent method](https://github.com/pixelcollective/acorn-block-templates/blob/2ae13d938badaf3f37860277c2a12ece09529ced/src/Providers/BlockTemplatesServiceProvider.php#L102) does not respect blocks with media only content (like "core/image"). Since a return of false will not render the block, I think this method should check for tags like `<img>`.