### PR TITLE
Registration of core blocks fails on WordPress 5.5

### DIFF
--- a/src/Providers/BlockTemplatesServiceProvider.php
+++ b/src/Providers/BlockTemplatesServiceProvider.php
@@ -19,7 +19,7 @@ class BlockTemplatesServiceProvider extends ServiceProvider
     {
         $this->blocks = Collection::make();
 
-        add_action('init', [$this, 'registerBlockTemplates']);
+        add_action('init', [$this, 'registerBlockTemplates'], 9);
     }
 
     /**


### PR DESCRIPTION
In WordPress 5.5 a lot changed to block registration (i.e. adding the [`register_core_block_types_from_metadata` function](https://core.trac.wordpress.org/changeset/48279)), so overriding core blocks will not succeed without decreasing the priority and run into a notice `Block type "core/columns" is already registered.`